### PR TITLE
Feat/create domain

### DIFF
--- a/src/main/java/com/service/BOOKJEOK/domain/ApprovalStatus.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/ApprovalStatus.java
@@ -1,0 +1,5 @@
+package com.service.BOOKJEOK.domain;
+
+public enum ApprovalStatus {
+    WAITING, CONFIRMED
+}

--- a/src/main/java/com/service/BOOKJEOK/domain/Club.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/Club.java
@@ -1,0 +1,70 @@
+package com.service.BOOKJEOK.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor //스프링이 User 객체 생성할 때 빈 생성자로 new를 하기 때문에
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "clubs")
+@Entity
+public class Club {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String img_url;
+    private String contents;
+    private int max_personnel;
+    private String description;
+    private int likes;
+    private String status;
+    private String tags;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    //ERD에 추가
+    @OneToMany(mappedBy = "club")
+    private final List<Member> memberList = new ArrayList<>();
+
+    //ERD에 추가
+    @OneToMany(mappedBy = "club")
+    private final List<Feed> feedList = new ArrayList<>();
+
+    @CreatedDate //insert
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate //insert, update
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Club(Long id, String title, String img_url, String contents, int max_personnel, String description, int likes, String status, String tags, User user, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.img_url = img_url;
+        this.contents = contents;
+        this.max_personnel = max_personnel;
+        this.description = description;
+        this.likes = likes;
+        this.status = status;
+        this.tags = tags;
+        this.user = user;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/service/BOOKJEOK/domain/Comment.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/Comment.java
@@ -1,0 +1,49 @@
+package com.service.BOOKJEOK.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor //스프링이 User 객체 생성할 때 빈 생성자로 new를 하기 때문에
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "comments")
+@Entity
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String contents;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+
+    @CreatedDate //insert
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate //insert, update
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Comment(Long id, String contents, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.contents = contents;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/service/BOOKJEOK/domain/Feed.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/Feed.java
@@ -36,6 +36,7 @@ public class Feed {
     @JoinColumn(name ="user_id")
     private User user;
 
+    //ERD에 추가
     @OneToMany(mappedBy = "feed")
     private final List<Comment> commentList = new ArrayList<>();
 

--- a/src/main/java/com/service/BOOKJEOK/domain/Feed.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/Feed.java
@@ -1,0 +1,62 @@
+package com.service.BOOKJEOK.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor //스프링이 User 객체 생성할 때 빈 생성자로 new를 하기 때문에
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "feeds")
+@Entity
+public class Feed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private int likes;
+    private String contents;
+    private String img_url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @ManyToOne
+    @JoinColumn(name ="user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "feed")
+    private final List<Comment> commentList = new ArrayList<>();
+
+    @CreatedDate //insert
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate //insert, update
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Feed(Long id, String title, int likes, String contents, String img_url, Club club, User user, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.likes = likes;
+        this.contents = contents;
+        this.img_url = img_url;
+        this.club = club;
+        this.user = user;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/service/BOOKJEOK/domain/LikedClub.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/LikedClub.java
@@ -1,0 +1,48 @@
+package com.service.BOOKJEOK.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor //스프링이 User 객체 생성할 때 빈 생성자로 new를 하기 때문에
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "likedclubs")
+@Entity
+public class LikedClub {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @CreatedDate //insert
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate //insert, update
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public LikedClub(Long id, User user, Club club, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.user = user;
+        this.club = club;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/service/BOOKJEOK/domain/LikedFeed.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/LikedFeed.java
@@ -1,0 +1,48 @@
+package com.service.BOOKJEOK.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor //스프링이 User 객체 생성할 때 빈 생성자로 new를 하기 때문에
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "likedfeeds")
+@Entity
+public class LikedFeed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+
+    @CreatedDate //insert
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate //insert, update
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public LikedFeed(Long id, User user, Feed feed, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.user = user;
+        this.feed = feed;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/service/BOOKJEOK/domain/Member.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/Member.java
@@ -1,0 +1,53 @@
+package com.service.BOOKJEOK.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor //스프링이 User 객체 생성할 때 빈 생성자로 new를 하기 때문에
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "members")
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ApprovalStatus status;
+
+    @CreatedDate //insert
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate //insert, update
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Member(Long id, User user, Club club, ApprovalStatus status, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.user = user;
+        this.club = club;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/service/BOOKJEOK/domain/User.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/User.java
@@ -1,0 +1,49 @@
+package com.service.BOOKJEOK.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor //스프링이 User 객체 생성할 때 빈 생성자로 new를 하기 때문에
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users")
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @Column(nullable = false, length = 40)
+    private String email;
+
+    private String img_url;
+
+    @CreatedDate //insert
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate //insert, update
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public User(Long id, String name, String email, String img_url, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.img_url = img_url;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}


### PR DESCRIPTION
## 🌴 PR 목적
- [ ] 기능 추가 : 도메인 생성, 모든 도메인에 생성/수정 날짜 추가, 일부 필드에 참조관계 추가.

## 🌴 기대결과
- 모든 도메인에 생성 / 수정 날짜 추가로 이후 피드 작성시간, 클럽 생성일 등의 기능 확장 시에 용이함.
- 일부 필드에 @OnetoMany 참조관계 추가로 추후 검색 기능 개발에 사용할 수 있음

## 🌴 전달사항
- 추가 사항을 ERD에도 반영해야함