### PR TITLE
[feat] create_club Api 로직 변경 & Member 도메인 "MASTER" 속성 추가

### DIFF
--- a/src/main/java/com/service/BOOKJEOK/domain/member/ApprovalStatus.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/member/ApprovalStatus.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ApprovalStatus {
-    WAITING("대기중"), CONFIRMED("승인됨");
+    MASTER("클럽장"), WAITING("대기중"), CONFIRMED("승인됨");
 
     private String value;
 }

--- a/src/main/java/com/service/BOOKJEOK/domain/member/Member.java
+++ b/src/main/java/com/service/BOOKJEOK/domain/member/Member.java
@@ -56,4 +56,7 @@ public class Member {
     public void updateState() {
         this.status = ApprovalStatus.CONFIRMED;
     }
+    public void master() {
+        this.status = ApprovalStatus.MASTER;
+    }
 }

--- a/src/main/java/com/service/BOOKJEOK/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/service/BOOKJEOK/repository/member/MemberRepositoryImpl.java
@@ -93,7 +93,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
                         member.status
                 ))
                 .from(member)
-                .where(member.user.id.eq(userId))
+                .where(member.user.id.eq(userId), member.status.eq(ApprovalStatus.CONFIRMED).or(member.status.eq(ApprovalStatus.MASTER)))
                 .fetch();
 
         return res;

--- a/src/main/java/com/service/BOOKJEOK/service/ClubService.java
+++ b/src/main/java/com/service/BOOKJEOK/service/ClubService.java
@@ -1,10 +1,12 @@
 package com.service.BOOKJEOK.service;
 
 import com.service.BOOKJEOK.domain.club.Club;
+import com.service.BOOKJEOK.domain.member.Member;
 import com.service.BOOKJEOK.domain.user.User;
 import com.service.BOOKJEOK.handler.ex.CustomApiException;
 import com.service.BOOKJEOK.handler.ex.ExMessage;
 import com.service.BOOKJEOK.repository.club.ClubRepository;
+import com.service.BOOKJEOK.repository.member.MemberRepository;
 import com.service.BOOKJEOK.repository.user.UserRepository;
 import com.service.BOOKJEOK.repository.comment.CommentRepository;
 import com.service.BOOKJEOK.repository.feed.FeedRepository;
@@ -28,7 +30,7 @@ public class ClubService {
     private final ClubRepository clubRepository;
     private final UserRepository userRepository;
     private final FeedRepository feedRepository;
-    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
     @Transactional
     public ClubCreateResDto createClub(ClubCreateReqDto requestDto) {
         User userPS = userRepository.findById(requestDto.getUserId()).orElseThrow(() -> new CustomApiException(ExMessage.NOT_FOUND_USER));
@@ -40,6 +42,14 @@ public class ClubService {
         Club club = requestDto.toEntity(userPS);
 
         Club savedClub = clubRepository.save(club);
+
+        Member myMember = Member.builder()
+                .user(userPS)
+                .club(savedClub)
+                .build();
+        myMember.master();
+
+        memberRepository.save(myMember);
 
         return new ClubCreateResDto(savedClub);
     }

--- a/src/test/java/com/service/BOOKJEOK/service/ClubServiceTest.java
+++ b/src/test/java/com/service/BOOKJEOK/service/ClubServiceTest.java
@@ -5,6 +5,7 @@ import com.service.BOOKJEOK.domain.club.TagEntity;
 import com.service.BOOKJEOK.domain.user.User;
 import com.service.BOOKJEOK.handler.ex.CustomApiException;
 import com.service.BOOKJEOK.repository.club.ClubRepository;
+import com.service.BOOKJEOK.repository.member.MemberRepository;
 import com.service.BOOKJEOK.repository.user.UserRepository;
 import com.service.BOOKJEOK.repository.comment.CommentRepository;
 import com.service.BOOKJEOK.repository.feed.FeedRepository;
@@ -37,6 +38,8 @@ class ClubServiceTest extends DummyObject {
     private ClubRepository clubRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private MemberRepository memberRepository;
     @Mock
     private FeedRepository feedRepository;
     @Mock

--- a/src/test/java/com/service/BOOKJEOK/service/LikedClubServiceTest.java
+++ b/src/test/java/com/service/BOOKJEOK/service/LikedClubServiceTest.java
@@ -120,6 +120,6 @@ class LikedClubServiceTest extends DummyObject {
 
         //then
         Assertions.assertThat(res.getTotalCount()).isEqualTo(1);
-        Assertions.assertThat(res.getClubList().get(0).getClubId()).isEqualTo(userID);
+        Assertions.assertThat(res.getLikedClubList().get(0).getClubId()).isEqualTo(userID);
     }
 }


### PR DESCRIPTION
## 🌴 PR 목적
- [ ] 기능 추가 : Member 도메인 Approval Status에 "MASTER" 속성 추가, 클럽 생성 API 로직 수정
- [ ] 기대 효과 : 클럽 생성시 클럽장도 클럽의 기능을 이용할 수 있도록 수정함